### PR TITLE
Enabled for Gnome 3.14 and 3.16

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,9 @@
 {
     "shell-version": [
         "3.10",
-        "3.12"
+        "3.12",
+        "3.14",
+        "3.16"
     ], 
     "uuid": "audio-output-switcher@anduchs", 
     "name": "Audio Output Switcher", 


### PR DESCRIPTION
I've been using the extension for quite a while now on both 3.14 and 3.16 and it seems to be working fine.
