### PR TITLE
Add support for 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
     "shell-version": [
         "3.10",
-        "3.12"
+        "3.12",
+        "3.20"
     ], 
     "uuid": "audio-output-switcher@anduchs", 
     "name": "Audio Output Switcher", 


### PR DESCRIPTION
I only actually added it to `metadata.json`, but it seems to have been enough to work on my machine.